### PR TITLE
Fix linking failure

### DIFF
--- a/include/anthywl.h
+++ b/include/anthywl.h
@@ -265,14 +265,3 @@ int anthywl_state_next_timer(struct anthywl_state *state);
 void anthywl_state_run_timers(struct anthywl_state *state);
 void anthywl_state_run(struct anthywl_state *state);
 void anthywl_state_finish(struct anthywl_state *state);
-
-struct zwp_input_popup_surface_v2_listener const
-    zwp_input_popup_surface_v2_listener;
-struct wl_seat_listener const wl_seat_listener;
-struct wl_surface_listener const wl_surface_listener;
-struct zwp_input_method_keyboard_grab_v2_listener const
-    zwp_input_method_keyboard_grab_v2_listener;
-struct zwp_input_method_v2_listener const zwp_input_method_v2_listener;
-struct wl_pointer_listener const wl_pointer_listener;
-struct wl_output_listener const wl_output_listener;
-struct wl_registry_listener const wl_registry_listener;

--- a/src/anthywl.c
+++ b/src/anthywl.c
@@ -45,6 +45,66 @@
     })
 
 
+struct zwp_input_popup_surface_v2_listener const
+    zwp_input_popup_surface_v2_listener =
+{
+    .text_input_rectangle = zwp_input_popup_surface_v2_text_input_rectangle,
+};
+
+struct wl_seat_listener const wl_seat_listener = {
+    .capabilities = wl_seat_capabilities,
+    .name = wl_seat_name,
+};
+
+struct wl_surface_listener const wl_surface_listener = {
+    .enter = wl_surface_enter,
+    .leave = wl_surface_leave,
+};
+
+struct zwp_input_method_keyboard_grab_v2_listener const
+    zwp_input_method_keyboard_grab_v2_listener =
+{
+    .keymap = zwp_input_method_keyboard_grab_v2_keymap,
+    .key = zwp_input_method_keyboard_grab_v2_key,
+    .modifiers = zwp_input_method_keyboard_grab_v2_modifiers,
+    .repeat_info = zwp_input_method_keyboard_grab_v2_repeat_info,
+};
+
+struct zwp_input_method_v2_listener const zwp_input_method_v2_listener =
+{
+    .activate = zwp_input_method_v2_activate,
+    .deactivate = zwp_input_method_v2_deactivate,
+    .surrounding_text = zwp_input_method_v2_surrounding_text,
+    .text_change_cause = zwp_input_method_v2_text_change_cause,
+    .content_type = zwp_input_method_v2_content_type,
+    .done = zwp_input_method_v2_done,
+    .unavailable = zwp_input_method_v2_unavailable,
+};
+
+struct wl_pointer_listener const wl_pointer_listener = {
+    .enter = wl_pointer_enter,
+    .leave = wl_pointer_leave,
+    .motion = wl_pointer_motion,
+    .button = wl_pointer_button,
+    .axis = wl_pointer_axis,
+    .frame = wl_pointer_frame,
+    .axis_source = wl_pointer_axis_source,
+    .axis_stop = wl_pointer_axis_stop,
+    .axis_discrete = wl_pointer_axis_discrete,
+};
+
+struct wl_output_listener const wl_output_listener = {
+    .geometry = wl_output_geometry,
+    .mode = wl_output_mode,
+    .done = wl_output_done,
+    .scale = wl_output_scale,
+};
+
+struct wl_registry_listener const wl_registry_listener = {
+    .global = wl_registry_global,
+    .global_remove = wl_registry_global_remove,
+};
+
 void zwp_input_popup_surface_v2_text_input_rectangle(void *data,
     struct zwp_input_popup_surface_v2 *zwp_input_popup_surface_v2,
     int32_t x, int32_t y, int32_t width, int32_t height)
@@ -1311,63 +1371,3 @@ int main(void) {
     anthywl_state_run(&state);
     anthywl_state_finish(&state);
 }
-
-struct zwp_input_popup_surface_v2_listener const
-    zwp_input_popup_surface_v2_listener =
-{
-    .text_input_rectangle = zwp_input_popup_surface_v2_text_input_rectangle,
-};
-
-struct wl_seat_listener const wl_seat_listener = {
-    .capabilities = wl_seat_capabilities,
-    .name = wl_seat_name,
-};
-
-struct wl_surface_listener const wl_surface_listener = {
-    .enter = wl_surface_enter,
-    .leave = wl_surface_leave,
-};
-
-struct zwp_input_method_keyboard_grab_v2_listener const
-    zwp_input_method_keyboard_grab_v2_listener =
-{
-    .keymap = zwp_input_method_keyboard_grab_v2_keymap,
-    .key = zwp_input_method_keyboard_grab_v2_key,
-    .modifiers = zwp_input_method_keyboard_grab_v2_modifiers,
-    .repeat_info = zwp_input_method_keyboard_grab_v2_repeat_info,
-};
-
-struct zwp_input_method_v2_listener const zwp_input_method_v2_listener =
-{
-    .activate = zwp_input_method_v2_activate,
-    .deactivate = zwp_input_method_v2_deactivate,
-    .surrounding_text = zwp_input_method_v2_surrounding_text,
-    .text_change_cause = zwp_input_method_v2_text_change_cause,
-    .content_type = zwp_input_method_v2_content_type,
-    .done = zwp_input_method_v2_done,
-    .unavailable = zwp_input_method_v2_unavailable,
-};
-
-struct wl_pointer_listener const wl_pointer_listener = {
-    .enter = wl_pointer_enter,
-    .leave = wl_pointer_leave,
-    .motion = wl_pointer_motion,
-    .button = wl_pointer_button,
-    .axis = wl_pointer_axis,
-    .frame = wl_pointer_frame,
-    .axis_source = wl_pointer_axis_source,
-    .axis_stop = wl_pointer_axis_stop,
-    .axis_discrete = wl_pointer_axis_discrete,
-};
-
-struct wl_output_listener const wl_output_listener = {
-    .geometry = wl_output_geometry,
-    .mode = wl_output_mode,
-    .done = wl_output_done,
-    .scale = wl_output_scale,
-};
-
-struct wl_registry_listener const wl_registry_listener = {
-    .global = wl_registry_global,
-    .global_remove = wl_registry_global_remove,
-};


### PR DESCRIPTION
During linking certain symbols were included twice leading to failure.

--
For reference I was getting.
```
ninja: Entering directory `build'
[22/22] Linking target src/anthywl
FAILED: src/anthywl
cc  -o src/anthywl src/anthywl.p/anthywl.c.o src/anthywl.p/actions.c.o src/anthywl.p/buffer.c.o src/anthywl.p/config.c.o src/anthywl.p/graphics_buffer.c.o -Wl,--as-needed -Wl,--no-undefined '-Wl,-rpath,$ORIGIN/../subprojects/libscfg-a4f023d2e1c2c2ac71eb23a989bd58bd3f77fb2a' -Wl,-rpath-link,/home/kchibisov/src/cc/anthywl/build/subprojects/libscfg-a4f023d2e1c2c2ac71eb23a989bd58bd3f77fb2a -Wl,--start-group protocol/libprotocols.a subprojects/libscfg-a4f023d2e1c2c2ac71eb23a989bd58bd3f77fb2a/libscfg.so /usr/lib64/libwayland-client.so /usr/lib64/libwayland-cursor.so /usr/lib64/libxkbcommon.so /usr/lib64/libanthy.so /usr/lib64/libanthydic.so /usr/lib64/libpango-1.0.so /usr/lib64/libgobject-2.0.so /usr/lib64/libglib-2.0.so /usr/lib64/libharfbuzz.so /usr/lib64/libcairo.so /usr/lib64/libpangocairo-1.0.so -Wl,--end-group
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:270: multiple definition of `zwp_input_popup_surface_v2_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:270: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:271: multiple definition of `wl_seat_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:271: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:272: multiple definition of `wl_surface_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:272: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:274: multiple definition of `zwp_input_method_keyboard_grab_v2_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:274: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:275: multiple definition of `zwp_input_method_v2_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:275: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:276: multiple definition of `wl_pointer_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:276: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:277: multiple definition of `wl_output_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:277: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/actions.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:278: multiple definition of `wl_registry_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:278: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:270: multiple definition of `zwp_input_popup_surface_v2_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:270: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:271: multiple definition of `wl_seat_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:271: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:272: multiple definition of `wl_surface_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:272: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:274: multiple definition of `zwp_input_method_keyboard_grab_v2_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:274: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:275: multiple definition of `zwp_input_method_v2_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:275: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:276: multiple definition of `wl_pointer_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:276: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:277: multiple definition of `wl_output_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:277: first defined here
/usr/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: src/anthywl.p/config.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:278: multiple definition of `wl_registry_listener'; src/anthywl.p/anthywl.c.o:/home/kchibisov/src/cc/anthywl/build/../include/anthywl.h:278: first defined here
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.

```

